### PR TITLE
Fixed `Attempt to call a nil value` at line 1542. Also Synced Updates

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -70,6 +70,15 @@ return setmetatable({
 		end
 		return luau_load(luau_compile(source, chunkname), env or getfenv(2))
 	end,
+	create_env = function(envwriter)
+			local fenv = getfenv(2)
+			local env = setmetatable({}, {
+				__index = function(self,k)
+					return envwriter[k] or fenv[k]
+				end,
+			})
+			return env
+		end,
 }, {
 	__call = function(self, source, env, chunkname)
 		return self.luau_execute(source, env or getfenv(2), chunkname)


### PR DESCRIPTION
`rt.store.copy(memory_at_0, destination, memory_at_0, source, size)` would error due to store.copy function missing. 
https://github.com/kosuke14/vLuau/blob/main/LuauInLuau.luau#1542

Also added `store.fill` by Syncing to latest version of [Wasynth](https://github.com/Rerumu/Wasynth/blob/0a303e1a4b9fae2cf8a04abdeec9f7d7d2381e74/codegen/luau/runtime/runtime.lua).

As well as, Synced to the Latest [Version from the Roblox Library](https://www.roblox.com/library/14382140693).
(_please keep them in sync if possible or at the very least make sure the Github repository is ahead_)